### PR TITLE
fix: track MC metrics and enforce unique CAS sampling

### DIFF
--- a/tests/test_cas_select.py
+++ b/tests/test_cas_select.py
@@ -1,0 +1,18 @@
+import numpy as np
+import pathlib, sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import cas4gnn_batch as c4g
+
+
+def test_cas_select_no_duplicates():
+    np.random.seed(0)
+    pen_grid = np.random.randn(10, 3)
+    unl = np.arange(10)
+    picks, _ = c4g.cas_select(unl, pen_grid, m_inc=5)
+    assert len(picks) == len(set(picks))
+
+    remaining = np.setdiff1d(unl, picks)
+    picks2, _ = c4g.cas_select(remaining, pen_grid, m_inc=3)
+    combined = np.concatenate([picks, picks2])
+    assert len(combined) == len(np.unique(combined))

--- a/tests/test_metrics_shapes.py
+++ b/tests/test_metrics_shapes.py
@@ -1,0 +1,34 @@
+import torch
+import pathlib, sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import cas4gnn_batch as c4g
+
+
+def dummy_train_round(net, data, train_idx, val_idx, opt, sched):
+    return net
+
+
+def test_metrics_shapes(monkeypatch):
+    monkeypatch.setattr(c4g, "train_round", dummy_train_round)
+    c4g.device = torch.device("cpu")
+    c4g.N_NODES = 20
+    c4g.TEST_FRAC = 0.2
+    c4g.VAL_COUNT = 2
+    c4g.M0 = 5
+    c4g.INC = 5
+    c4g.ROUNDS = 5
+    c4g.SEEDS = range(1)
+
+    cas_m, cas_s, r_m, r_s, mc_m, mc_s = c4g.run_setting([8, 8], "relu", torch.relu)
+
+    assert cas_m.size == cas_s.size
+    assert mc_m.size == mc_s.size
+
+    grid_size = int((1 - c4g.TEST_FRAC) * c4g.N_NODES) - c4g.VAL_COUNT
+    unlab_initial = grid_size - c4g.M0
+    expected_inc = (unlab_initial + c4g.INC - 1) // c4g.INC if unlab_initial > 0 else 0
+    expected_rounds = expected_inc + 1
+
+    assert cas_m.shape[0] == mc_m.shape[0] == expected_rounds
+    assert r_m.shape[0] == expected_inc


### PR DESCRIPTION
## Summary
- ensure CAS selection never repeats nodes within an increment
- record Monte Carlo metrics alongside CAS and plot both strategies
- add tests for sampler uniqueness and metric shapes

## Testing
- `pytest -q`
- `python - <<'PY'
import cas4gnn_batch as c
import torch
c.SEEDS = range(1)
c.N_NODES = 50
c.TEST_FRAC = 0.2
c.VAL_COUNT = 5
c.M0 = 10
c.INC = 10
c.ROUNDS = 2
c.device = torch.device('cpu')
cas_m, cas_s, r_m, r_s, mc_m, mc_s = c.run_setting([8,8], 'relu', torch.relu)
print('CAS MSE:', cas_m)
print('MC MSE:', mc_m)
PY`


------
https://chatgpt.com/codex/tasks/task_e_689e15be2738833181170b7ed7a4a18d