### PR TITLE
ci: add workflow to install CPU torch and PyG wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install "torch>=2.2,<3.0" --index-url https://download.pytorch.org/whl/cpu
+          pip install \
+            "torch-geometric>=2.5,<3.0" \
+            "torch-scatter>=2.1,<3.0" \
+            "torch-sparse>=0.6,<1.0" \
+            "torch-cluster>=1.6,<2.0" \
+            "torch-spline-conv>=1.2,<2.0" \
+            -f https://data.pyg.org/whl/torch-2.2.0+cpu.html
+          pip install numpy scipy scikit-learn networkx matplotlib pytest
+      - name: Run tests
+        run: pytest


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow installing CPU-only torch and PyTorch Geometric wheels, then running pytest

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch_geometric')*


------
https://chatgpt.com/codex/tasks/task_e_68a0ba8a801c8331b1886dc85296d3ef