### PR TITLE
feat: add round-wise logging and histories

### DIFF
--- a/tests/test_label_scaling.py
+++ b/tests/test_label_scaling.py
@@ -11,8 +11,8 @@ import cas4gnn_batch as c4g
 from sklearn.preprocessing import StandardScaler
 
 
-def dummy_train_round(net, data, train_idx, val_idx, opt, sched):
-    return net
+def dummy_train_round(net, data, train_idx, val_idx, **kwargs):
+    return net, [], [], []
 
 
 def test_scaler_uses_train_only(monkeypatch):

--- a/tests/test_metrics_shapes.py
+++ b/tests/test_metrics_shapes.py
@@ -5,8 +5,8 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 import cas4gnn_batch as c4g
 
 
-def dummy_train_round(net, data, train_idx, val_idx, opt, sched):
-    return net
+def dummy_train_round(net, data, train_idx, val_idx, **kwargs):
+    return net, [], [], []
 
 
 def test_metrics_shapes(monkeypatch):
@@ -20,7 +20,7 @@ def test_metrics_shapes(monkeypatch):
     c4g.ROUNDS = 5
     c4g.SEEDS = range(1)
 
-    cas_m, cas_s, r_m, r_s, mc_m, mc_s = c4g.run_setting([8, 8], "relu", torch.relu)
+    cas_m, cas_s, r_m, r_s, mc_m, mc_s, _ = c4g.run_setting([8, 8], "relu", torch.relu)
 
     assert cas_m.size == cas_s.size
     assert mc_m.size == mc_s.size


### PR DESCRIPTION
## Summary
- reset optimizer each active-learning round, track LR scheduler on validation cadence, and clip gradients
- log pre-/post-round losses and CAS stats, returning full histories
- expose `--chk` flag to control validation cadence and update tests for new train API

## Testing
- `pytest -q`
- `python cas4gnn_batch.py --help` *(fails: ModuleNotFoundError: No module named 'torch_geometric')*
- `python cas4gnn_batch.py --smoke --chk 5 --cpu` *(fails: ModuleNotFoundError: No module named 'torch_geometric')*


------
https://chatgpt.com/codex/tasks/task_e_68ab96d4d0a483319515aca248e81bc8